### PR TITLE
Terser configs via flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 /test-results
 /user
 .env
+/.idea/
+/terser.json

--- a/Readme.md
+++ b/Readme.md
@@ -54,19 +54,19 @@ npx tvkit@latest build path/to/build --out path/to/output --browser "chrome 50"
 
 ## tvkit build
 
-| Option         | Default value | Description                                                                 |
-| -------------- | ------------- | --------------------------------------------------------------------------- |
-| [folder]       |               | The folder containing modern javascript                                     |
-| --out          |               | The output folder                                                           |
-| --browser      |               | The transpilation target (uses browserslist)                                |
-| --force        | false         | Overwrite files in output folder                                            |
-| --add          |               | Override feature. Ex `--add "es6-module"` forces adding systemjs polyfill   |
-| --remove       |               | Override feature: Ex `--remove fetch` forces omitting whatwg-fetch polyfill |
-| --no-css       | false         | Disable CSS transpilation                                                   |
-| --no-minify    | false         | Disable minificaton                                                         |
-| --quiet        | false         | Only log errors                                                             |
-| --terser-config|               | Path to the JSON terser config file                                         |
-| --help         |               | Show message per command. Ex: `tvkit build --help`                          |
+| Option           | Default value | Description                                                                 |
+|------------------| ------------- | --------------------------------------------------------------------------- |
+| [folder]         |               | The folder containing modern javascript                                     |
+| --out            |               | The output folder                                                           |
+| --browser        |               | The transpilation target (uses browserslist)                                |
+| --force          | false         | Overwrite files in output folder                                            |
+| --add            |               | Override feature. Ex `--add "es6-module"` forces adding systemjs polyfill   |
+| --remove         |               | Override feature: Ex `--remove fetch` forces omitting whatwg-fetch polyfill |
+| --no-css         | false         | Disable CSS transpilation                                                   |
+| --no-minify      | false         | Disable minificaton                                                         |
+| --quiet          | false         | Only log errors                                                             |
+| --terser-config  |               | Path to the JSON terser config file                                         |
+| --help           |               | Show message per command. Ex: `tvkit build --help`                          |
 
 Note: Polyfilling will degrade the performance for platforms that could've run the modern javascript version.
 An alternative to `tvkit build` is using [@vitejs/plugin-legacy](https://www.npmjs.com/package/@vitejs/plugin-legacy) which has better performance on modern browsers, but doesn't work for some project setups (like SvelteKit projects).

--- a/Readme.md
+++ b/Readme.md
@@ -13,18 +13,19 @@ TVKit intercepts requests to a webserver and converts the responses to make them
 
 ## tvkit serve
 
-| Option      | Default value         | Description                                                                 |
-| ----------- | --------------------- | --------------------------------------------------------------------------- |
-| [target]    | http://localhost:5173 | The URL of the website that is too new                                      |
-| --port      | 3000                  | The port the proxy server is going to run on                                |
-| --browser   |                       | The transpilation target (uses browserslist)                                |
-| --add       |                       | Override feature. Ex `--add "es6-module"` forces adding systemjs polyfill   |
-| --remove    |                       | Override feature: Ex `--remove fetch` forces omitting whatwg-fetch polyfill |
-| --no-css    | false                 | Disable CSS transpilation                                                   |
-| --ssl-cert  |                       | Path to the SSL certificate for https                                       |
-| --ssl-key   |                       | Path to the SSL certificate's private key                                   |
-| --no-minify | false                 | Disable minificaton for the polyfills                                       |
-| --help      |                       | Show message per command. Ex: `tvkit serve --help`                          |
+| Option         | Default value         | Description                                                                 |
+| -------------- | --------------------- | --------------------------------------------------------------------------- |
+| [target]       | http://localhost:5173 | The URL of the website that is too new                                      |
+| --port         | 3000                  | The port the proxy server is going to run on                                |
+| --browser      |                       | The transpilation target (uses browserslist)                                |
+| --add          |                       | Override feature. Ex `--add "es6-module"` forces adding systemjs polyfill   |
+| --remove       |                       | Override feature: Ex `--remove fetch` forces omitting whatwg-fetch polyfill |
+| --no-css       | false                 | Disable CSS transpilation                                                   |
+| --ssl-cert     |                       | Path to the SSL certificate for https                                       |
+| --ssl-key      |                       | Path to the SSL certificate's private key                                   |
+| --no-minify    | false                 | Disable minificaton for the polyfills                                       |
+| --terser-config|                       | Path to the JSON terser config file                                         |
+| --help         |                       | Show message per command. Ex: `tvkit serve --help`                          |
 
 TVKit adds browser aliases for SmartTV platforms:
 Example `--browser "Tizen 5"` is aliased to `Chrome 63`
@@ -53,18 +54,19 @@ npx tvkit@latest build path/to/build --out path/to/output --browser "chrome 50"
 
 ## tvkit build
 
-| Option      | Default value | Description                                                                 |
-| ----------- | ------------- | --------------------------------------------------------------------------- |
-| [folder]    |               | The folder containing modern javascript                                     |
-| --out       |               | The output folder                                                           |
-| --browser   |               | The transpilation target (uses browserslist)                                |
-| --force     | false         | Overwrite files in output folder                                            |
-| --add       |               | Override feature. Ex `--add "es6-module"` forces adding systemjs polyfill   |
-| --remove    |               | Override feature: Ex `--remove fetch` forces omitting whatwg-fetch polyfill |
-| --no-css    | false         | Disable CSS transpilation                                                   |
-| --no-minify | false         | Disable minificaton                                                         |
-| --quiet     | false         | Only log errors                                                             |
-| --help      |               | Show message per command. Ex: `tvkit build --help`                          |
+| Option         | Default value | Description                                                                 |
+| -------------- | ------------- | --------------------------------------------------------------------------- |
+| [folder]       |               | The folder containing modern javascript                                     |
+| --out          |               | The output folder                                                           |
+| --browser      |               | The transpilation target (uses browserslist)                                |
+| --force        | false         | Overwrite files in output folder                                            |
+| --add          |               | Override feature. Ex `--add "es6-module"` forces adding systemjs polyfill   |
+| --remove       |               | Override feature: Ex `--remove fetch` forces omitting whatwg-fetch polyfill |
+| --no-css       | false         | Disable CSS transpilation                                                   |
+| --no-minify    | false         | Disable minificaton                                                         |
+| --quiet        | false         | Only log errors                                                             |
+| --terser-config|               | Path to the JSON terser config file                                         |
+| --help         |               | Show message per command. Ex: `tvkit build --help`                          |
 
 Note: Polyfilling will degrade the performance for platforms that could've run the modern javascript version.
 An alternative to `tvkit build` is using [@vitejs/plugin-legacy](https://www.npmjs.com/package/@vitejs/plugin-legacy) which has better performance on modern browsers, but doesn't work for some project setups (like SvelteKit projects).

--- a/bin/tvkit.js
+++ b/bin/tvkit.js
@@ -51,6 +51,10 @@ await Yargs(hideBin(process.argv))
         type: "boolean",
         describe: "Toggle minification for polyfills",
       });
+      yargs.option("terser-config", {
+        type: "string",
+        describe: "Path to the JSON terser config file, used for minification",
+      });
     },
     async (argv) => {
       /** @type {Parameters<typeof serve>[4]} */
@@ -71,6 +75,7 @@ await Yargs(hideBin(process.argv))
         {
           css: argv.css,
           minify: argv.minify,
+          terserConfig: argv.terserConfig,
         },
       );
     },
@@ -123,6 +128,10 @@ await Yargs(hideBin(process.argv))
         default: false,
         describe: "Only show error output",
       });
+      yargs.option("terser-config", {
+        type: "string",
+        describe: "Path to the JSON terser config file, used for minification",
+      });
     },
     async (argv) => {
       if (argv.out === "") {
@@ -141,6 +150,7 @@ await Yargs(hideBin(process.argv))
           minify: argv.minify,
           force: argv.force,
           quiet: argv.quiet,
+          terserConfigPath: argv.terserConfig,
         },
       );
     },

--- a/src/babelRuntime.js
+++ b/src/babelRuntime.js
@@ -20,8 +20,8 @@ export default async function babelRuntime(
 
   if (minify) {
     // Use custom terser config if provided, otherwise use default
+    /** @type {import("terser").MinifyOptions} */
     const terserOptions = terserConfig || { ecma: 5, safari10: true };
-    // @ts-ignore - we know this is compatible with terser options
     plugins.push(terser(terserOptions));
   }
   const builder = await rollup({

--- a/src/babelRuntime.js
+++ b/src/babelRuntime.js
@@ -10,12 +10,19 @@ import isSupported from "./isSupported.js";
  * Generate a @babel/runtime helper as an importable modules.
  *
  * @param {string} module
- * @param {{browsers: string[], minify?:boolean}} options
+ * @param {{browsers: string[], minify?:boolean, terserConfig?: Object}} options
  */
-export default async function babelRuntime(module, { browsers, minify }) {
+export default async function babelRuntime(
+  module,
+  { browsers, minify, terserConfig },
+) {
   const plugins = [commonjs()];
+
   if (minify) {
-    plugins.push(terser({ ecma: 5, safari10: true }));
+    // Use custom terser config if provided, otherwise use default
+    const terserOptions = terserConfig || { ecma: 5, safari10: true };
+    // @ts-ignore - we know this is compatible with terser options
+    plugins.push(terser(terserOptions));
   }
   const builder = await rollup({
     input: await resolveFilename(module),

--- a/src/build.js
+++ b/src/build.js
@@ -1,6 +1,6 @@
 // @ts-check
 import fs from "fs/promises";
-import { existsSync, createReadStream, createWriteStream } from "fs";
+import { createReadStream, createWriteStream, existsSync } from "fs";
 import path from "path";
 import zlib from "zlib";
 import * as terser from "terser";
@@ -54,6 +54,7 @@ export default async function build(
   const { publicFolder, justCopy, sveltekit } = await detectPreset(folder);
 
   // Load terser configuration if provided
+  /** @type {import("terser").MinifyOptions} */
   let terserConfig = { ecma: 5, safari10: true };
   if (terserConfigPath) {
     try {
@@ -61,9 +62,8 @@ export default async function build(
         path.resolve(terserConfigPath),
         "utf-8",
       );
-      const parsedConfig = JSON.parse(terserConfigContent);
-      // Merge with default configuration
-      terserConfig = { ...terserConfig, ...parsedConfig };
+
+      terserConfig = JSON.parse(terserConfigContent);
 
       log("[tvkit]", {
         message: `loaded config for terser from ${terserConfigPath}`,
@@ -154,7 +154,7 @@ export default async function build(
 /**
  * @param {string} folder
  * @param {string} out
- * @param {{base: string, browsers: string[], root: string, css: boolean, minify: boolean, terserConfig?: Object, justCopy: boolean | string[], log: (...args:any[]) => void }} options
+ * @param {{base: string, browsers: string[], root: string, css: boolean, minify: boolean, terserConfig?: import("terser").MinifyOptions, justCopy: boolean | string[], log: (...args:any[]) => void }} options
  */
 async function processFolder(
   folder,
@@ -221,7 +221,6 @@ async function processFolder(
               }
               try {
                 // Use custom terser config if provided
-                // @ts-ignore - we know this is compatible with terser options
                 const minified = await terser.minify(code, terserConfig);
                 return minified.code ?? code;
               } catch (/** @type {any} */ err) {

--- a/src/generatePolyfills.js
+++ b/src/generatePolyfills.js
@@ -207,7 +207,6 @@ if (typeof new Error().stack !== "string") {
   await fs.writeFile(input, source, "utf8");
   const plugins = [commonjs()];
   if (minify) {
-    // @ts-ignore - we know this is compatible with terser options
     plugins.push(terser(terserConfig));
   }
   const builder = await rollup({ input, plugins, watch: false });

--- a/src/generatePolyfills.js
+++ b/src/generatePolyfills.js
@@ -12,13 +12,14 @@ import isSupported from "./isSupported.js";
 const require = createRequire(import.meta.url);
 
 /**
- * @param {{browsers: string[], supports: Record<string, boolean>, minify: boolean}} options
+ * @param {{browsers: string[], supports: Record<string, boolean>, minify: boolean, terserConfig?: Object}} options
  * @returns {Promise<string>} javascript code
  */
 export default async function generatePolyfills({
   browsers,
   supports,
   minify,
+  terserConfig = { ecma: 5, safari10: true },
 }) {
   const folder = await tmpFolder(browsers, supports);
   const file = path.join(folder, `polyfills${minify ? ".min" : ""}.js`);
@@ -206,7 +207,8 @@ if (typeof new Error().stack !== "string") {
   await fs.writeFile(input, source, "utf8");
   const plugins = [commonjs()];
   if (minify) {
-    plugins.push(terser({ ecma: 5, safari10: true }));
+    // @ts-ignore - we know this is compatible with terser options
+    plugins.push(terser(terserConfig));
   }
   const builder = await rollup({ input, plugins, watch: false });
   const result = await builder.write({ format: "iife", file });


### PR DESCRIPTION
This PR adds the ability to specify a custom Terser #19  configuration file via the `--terser-config` command line option. This enhancement allows users to fine-tune the JavaScript minification process to meet their specific needs.

The custom Terser configuration is only applied when minification is enabled `(minify = true)`.